### PR TITLE
Missing gulp babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "jquery": "latest",
         "fastclick": "latest",
 
+        "gulp-babel": "^4.0.0",
         "node-bourbon": "latest",
         "gulp-sass": "latest",
         "gulp-iconfont": "latest",


### PR DESCRIPTION
This adds gulp-babel to your package.json. `gulp` doesn't work without it.
